### PR TITLE
Adding a .travis.yml file to support Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+    - 5.6
+    - 7.0
+    - 7.1
+    - hhvm
+    - nightly
+
+install:
+    composer install --prefer-dist
+
+script:
+    phpunit --configuration web/tests/phpunit.xml

--- a/web/tests/bootstrap.php
+++ b/web/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . "/../../vendor/autoload.php";

--- a/web/tests/phpunit.xml
+++ b/web/tests/phpunit.xml
@@ -1,0 +1,10 @@
+<phpunit backupGlobals="true" bootstrap="./bootstrap.php">
+    <filter>
+        <whitelist>
+            <directory>/fatfree</directory>
+        </whitelist>
+    </filter>
+    <testsuite>
+        <directory>./</directory>
+    </testsuite>
+</phpunit>


### PR DESCRIPTION
This is the most basic build file I could create.  It can't support anything before PHP 5.6 since the PHPUnit has some dependencies that require PHP >=5.6.

It currently doesn't run any tests.