### PR TITLE
Adding support code Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,29 @@
+engines:
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - javascript
+        - php
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
+  phpcodesniffer:
+    enabled: true
+    config:
+      standard: "PSR1,PSR2"
+  phpmd:
+    enabled: true
+    config:
+      rulesets: "cleancode,controversial,design,unusedcode,phpmdruleset.xml"
+ratings:
+  paths:
+    - "**.css"
+    - "**.js"
+    - "**.php"
+exclude_paths:
+  - "web/fatfree/lib"
+  - "web/fatfree/javascript/js.cookie.js"

--- a/phpmdruleset.xml
+++ b/phpmdruleset.xml
@@ -1,0 +1,23 @@
+ <?xml version="1.0"?>
+ <ruleset name="PHPMD rule set for RoboHome" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+          xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+     <description>PHPMD rule set for RoboHome</description>
+     <rule ref="rulesets/codesize.xml">
+         <exclude name="ExcessiveMethodLength" />
+     </rule>
+     <rule ref="rulesets/naming.xml">
+         <exclude name="ShortVariable" />
+     </rule>
+     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+         <properties>
+             <property name="minimum" value="25" />
+         </properties>
+     </rule>
+     <rule ref="rulesets/naming.xml/ShortVariable">
+         <properties>
+             <property name="exceptions" value="db,f3,id" />
+         </properties>
+     </rule>
+ </ruleset>

--- a/phpmdruleset.xml
+++ b/phpmdruleset.xml
@@ -1,23 +1,23 @@
- <?xml version="1.0"?>
- <ruleset name="PHPMD rule set for RoboHome" xmlns="http://pmd.sf.net/ruleset/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-          xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
-     <description>PHPMD rule set for RoboHome</description>
-     <rule ref="rulesets/codesize.xml">
-         <exclude name="ExcessiveMethodLength" />
-     </rule>
-     <rule ref="rulesets/naming.xml">
-         <exclude name="ShortVariable" />
-     </rule>
-     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
-         <properties>
-             <property name="minimum" value="25" />
-         </properties>
-     </rule>
-     <rule ref="rulesets/naming.xml/ShortVariable">
-         <properties>
-             <property name="exceptions" value="db,f3,id" />
-         </properties>
-     </rule>
- </ruleset>
+<?xml version="1.0"?>
+<ruleset name="PHPMD rule set for RoboHome" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>PHPMD rule set for RoboHome</description>
+    <rule ref="rulesets/codesize.xml">
+        <exclude name="ExcessiveMethodLength" />
+    </rule>
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable" />
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="25" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="exceptions" value="db,f3,id" />
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
-Added custom ruleset to allow the PHP variable names $db, $f3, and $id
-Added custom ruleset to force methods to be max 25 lines long

Thanks to @leftees at Code Climate for helping me figure out what I did wrong the first time!  This PR will suppressed #16 since it squashed all the commits together.