### PR TITLE
Fix for 403 Error that occurred on logout sometimes

### DIFF
--- a/web/fatfree/app/controllers/LoginController.php
+++ b/web/fatfree/app/controllers/LoginController.php
@@ -36,8 +36,8 @@ class LoginController extends Controller
 
     private function redirectLoggedInUserToDevicesPage($f3)
     {
-        if ($f3->get("SESSION.user") !== null) {
-            if ($f3->get("ALIAS") == "loginPage") {
+        if (!$f3->devoid("SESSION.user")) {
+            if ($f3->get("ALIAS") === "loginPage") {
                 $f3->reroute("@devices");
             }
         }


### PR DESCRIPTION
-This was a hard error to reproduce, but I believe it had to do with the differences in how the `SESSION.user` variable was being checked.  Regardless, this is still a cleaner implementation.